### PR TITLE
Removing the '../' and setting the glossary base URL to be the root o…

### DIFF
--- a/mdtooltipslink.py
+++ b/mdtooltipslink.py
@@ -112,7 +112,7 @@ class DefinitionPattern(Pattern):
             linktext = text.lower() if len(singulartext) == 0 else singulartext
             elem.set(
                 "href",
-                "../{}/index.html#{}".format(basename, linktext.replace(" ", "-")),
+                "/{}/#{}".format(basename, linktext.replace(" ", "-")),
             )
         else:
             elem = markdown.util.etree.Element("span")


### PR DESCRIPTION
Removing the `../` and setting the glossary base URL to be the root of the website.

The rationale being that relative URLs like `../` are not reliable. Better to just have the glossary in the root and assume it is always located a `https://example.com/glossary/`.

Also, removing the explicit `index.html` since it shouldn’t really be referenced since all major web servers — such as Apache — knows by default to serve `index.html` anyway if a directory path like `glossary/` is accessed.